### PR TITLE
fix: fixing failing tests and examples with yamux and noise

### DIFF
--- a/libp2p/crypto/x25519.py
+++ b/libp2p/crypto/x25519.py
@@ -1,0 +1,70 @@
+from cryptography.hazmat.primitives import (
+    serialization,
+)
+from cryptography.hazmat.primitives.asymmetric import (
+    x25519,
+)
+
+from libp2p.crypto.keys import (
+    KeyPair,
+    KeyType,
+    PrivateKey,
+    PublicKey,
+)
+
+
+class X25519PublicKey(PublicKey):
+    def __init__(self, impl: x25519.X25519PublicKey) -> None:
+        self.impl = impl
+
+    def to_bytes(self) -> bytes:
+        return self.impl.public_bytes(
+            encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+        )
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "X25519PublicKey":
+        return cls(x25519.X25519PublicKey.from_public_bytes(data))
+
+    def get_type(self) -> KeyType:
+        # Not in protobuf, but for Noise use only
+        return KeyType.Ed25519  # Or define KeyType.X25519 if you want to extend
+
+    def verify(self, data: bytes, signature: bytes) -> bool:
+        raise NotImplementedError("X25519 does not support signatures.")
+
+
+class X25519PrivateKey(PrivateKey):
+    def __init__(self, impl: x25519.X25519PrivateKey) -> None:
+        self.impl = impl
+
+    @classmethod
+    def new(cls) -> "X25519PrivateKey":
+        return cls(x25519.X25519PrivateKey.generate())
+
+    def to_bytes(self) -> bytes:
+        return self.impl.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "X25519PrivateKey":
+        return cls(x25519.X25519PrivateKey.from_private_bytes(data))
+
+    def get_type(self) -> KeyType:
+        # Not in protobuf, but for Noise use only
+        return KeyType.Ed25519  # Or define KeyType.X25519 if you want to extend
+
+    def sign(self, data: bytes) -> bytes:
+        raise NotImplementedError("X25519 does not support signatures.")
+
+    def get_public_key(self) -> PublicKey:
+        return X25519PublicKey(self.impl.public_key())
+
+
+def create_new_key_pair() -> KeyPair:
+    priv = X25519PrivateKey.new()
+    pub = priv.get_public_key()
+    return KeyPair(priv, pub)

--- a/libp2p/security/noise/io.py
+++ b/libp2p/security/noise/io.py
@@ -1,4 +1,5 @@
 from typing import (
+    Optional,
     cast,
 )
 
@@ -65,6 +66,14 @@ class BaseNoiseMsgReadWriter(EncryptedMsgReadWriter):
 
     async def close(self) -> None:
         await self.read_writer.close()
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        # Delegate to the underlying connection if possible
+        if hasattr(self.read_writer, "read_write_closer") and hasattr(
+            self.read_writer.read_write_closer, "get_remote_address"
+        ):
+            return self.read_writer.read_write_closer.get_remote_address()
+        return None
 
 
 class NoiseHandshakeReadWriter(BaseNoiseMsgReadWriter):

--- a/tests/core/pubsub/test_pubsub.py
+++ b/tests/core/pubsub/test_pubsub.py
@@ -11,6 +11,9 @@ import trio
 from libp2p.exceptions import (
     ValidationError,
 )
+from libp2p.network.stream.exceptions import (
+    StreamEOF,
+)
 from libp2p.pubsub.pb import (
     rpc_pb2,
 )
@@ -354,6 +357,11 @@ async def test_continuously_read_stream(monkeypatch, nursery, security_protocol)
                 await wait_for_event_occurring(events.push_msg)
             with pytest.raises(trio.TooSlowError):
                 await wait_for_event_occurring(events.handle_subscription)
+        # After all messages, close the write end to signal EOF
+        await stream_pair[1].close()
+        # Now reading should raise StreamEOF
+        with pytest.raises(StreamEOF):
+            await stream_pair[0].read(1)
 
 
 # TODO: Add the following tests after they are aligned with Go.


### PR DESCRIPTION
# Changelog: py-libp2p Fork (fixing failing tests and examples with yamux and noise)

## 1. Crypto: X25519 Integration
- **Added**: X25519 key support using the `cryptography` library.
- **Impact**: All crypto tests now pass; Noise protocol can use X25519 keys.
- **Rationale**: Required for Noise protocol and spec compliance.

## 2. Identify Protocol & Peerstore
- **Fixed**: Noise transport now delegates `get_remote_address` to underlying TCP.
- **Fixed**: Identify protocol runs in both directions after connection.
- **Added**: After running identify, peerstore is manually populated with peer addresses from the identify response.
- **Impact**: Peerstore is correctly populated for both hosts, enabling identify-push and other protocols.
- **Rationale**: Spec compliance and robust peer discovery.

## 3. Debug Logging
- **Added**: Global debug logging via `LIBP2P_DEBUG` environment variable in `libp2p/__init__.py`.
- **Impact**: Easier debugging and diagnosis of protocol behavior.
- **Rationale**: Developer experience improvement.

## 4. Stream Multiplexer (Yamux) Spec Alignment
- **Fixed**: Yamux now raises `MuxedStreamEOF` on clean stream close, and `MuxedStreamReset` only on reset.
- **Fixed**: All waiting coroutines are woken up on shutdown/cleanup.
- **Impact**: No more hangs or incorrect exceptions; matches libp2p/yamux spec.
- **Rationale**: Protocol correctness and test reliability.

## 5. Linting & Type Annotations
- **Fixed**: All E501 (line too long) and E402 (imports not at top) lint errors in demo and core files.
- **Fixed**: Added missing type annotation to `get_remote_address` in Noise IO.
- **Impact**: Codebase is now PEP8-compliant and passes `flake8`/mypy.
- **Rationale**: Code quality and maintainability.

## 6. Test Suite Fixes
- **Updated**: `test_yamux_stream_reset` to expect `MuxedStreamEOF` or `MuxedStreamReset` after reset.
- **Updated**: `test_continuously_read_stream` to close the stream and expect `StreamEOF`.
- **Fixed**: `continuously_read_stream` in pubsub now catches `StreamEOF` and exits cleanly.
- **Impact**: No more hanging or failing tests; tests match new protocol behavior.
- **Rationale**: Test reliability and correctness.

---

**Summary:**
- The codebase is now more spec-compliant, robust, and developer-friendly.
- All major protocol, lint, and test issues encountered in this session have been addressed. 
