### PR TITLE
Feature/replace mplex with yamux

### DIFF
--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -2,8 +2,7 @@ from collections.abc import (
     Mapping,
 )
 from importlib.metadata import version as __version
-import logging
-import os
+
 from typing import (
     Literal,
     Optional,

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -2,7 +2,6 @@ from collections.abc import (
     Mapping,
 )
 from importlib.metadata import version as __version
-
 from typing import (
     Literal,
     Optional,

--- a/libp2p/crypto/x25519.py
+++ b/libp2p/crypto/x25519.py
@@ -1,0 +1,70 @@
+from cryptography.hazmat.primitives import (
+    serialization,
+)
+from cryptography.hazmat.primitives.asymmetric import (
+    x25519,
+)
+
+from libp2p.crypto.keys import (
+    KeyPair,
+    KeyType,
+    PrivateKey,
+    PublicKey,
+)
+
+
+class X25519PublicKey(PublicKey):
+    def __init__(self, impl: x25519.X25519PublicKey) -> None:
+        self.impl = impl
+
+    def to_bytes(self) -> bytes:
+        return self.impl.public_bytes(
+            encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+        )
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "X25519PublicKey":
+        return cls(x25519.X25519PublicKey.from_public_bytes(data))
+
+    def get_type(self) -> KeyType:
+        # Not in protobuf, but for Noise use only
+        return KeyType.Ed25519  # Or define KeyType.X25519 if you want to extend
+
+    def verify(self, data: bytes, signature: bytes) -> bool:
+        raise NotImplementedError("X25519 does not support signatures.")
+
+
+class X25519PrivateKey(PrivateKey):
+    def __init__(self, impl: x25519.X25519PrivateKey) -> None:
+        self.impl = impl
+
+    @classmethod
+    def new(cls) -> "X25519PrivateKey":
+        return cls(x25519.X25519PrivateKey.generate())
+
+    def to_bytes(self) -> bytes:
+        return self.impl.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "X25519PrivateKey":
+        return cls(x25519.X25519PrivateKey.from_private_bytes(data))
+
+    def get_type(self) -> KeyType:
+        # Not in protobuf, but for Noise use only
+        return KeyType.Ed25519  # Or define KeyType.X25519 if you want to extend
+
+    def sign(self, data: bytes) -> bytes:
+        raise NotImplementedError("X25519 does not support signatures.")
+
+    def get_public_key(self) -> PublicKey:
+        return X25519PublicKey(self.impl.public_key())
+
+
+def create_new_key_pair() -> KeyPair:
+    priv = X25519PrivateKey.new()
+    pub = priv.get_public_key()
+    return KeyPair(priv, pub)

--- a/libp2p/security/noise/io.py
+++ b/libp2p/security/noise/io.py
@@ -1,4 +1,5 @@
 from typing import (
+    Optional,
     cast,
 )
 
@@ -65,6 +66,14 @@ class BaseNoiseMsgReadWriter(EncryptedMsgReadWriter):
 
     async def close(self) -> None:
         await self.read_writer.close()
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        # Delegate to the underlying connection if possible
+        if hasattr(self.read_writer, "read_write_closer") and hasattr(
+            self.read_writer.read_write_closer, "get_remote_address"
+        ):
+            return self.read_writer.read_write_closer.get_remote_address()
+        return None
 
 
 class NoiseHandshakeReadWriter(BaseNoiseMsgReadWriter):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,6 @@
 import pytest
 
-from tests.utils.factories import (
-    HostFactory,
-)
-
 
 @pytest.fixture
 def security_protocol():
     return None
-
-
-@pytest.fixture
-def num_hosts():
-    return 3
-
-
-@pytest.fixture
-async def hosts(num_hosts, security_protocol, nursery):
-    async with HostFactory.create_batch_and_listen(
-        num_hosts, security_protocol=security_protocol
-    ) as _hosts:
-        yield _hosts

--- a/tests/core/pubsub/test_pubsub.py
+++ b/tests/core/pubsub/test_pubsub.py
@@ -11,6 +11,9 @@ import trio
 from libp2p.exceptions import (
     ValidationError,
 )
+from libp2p.network.stream.exceptions import (
+    StreamEOF,
+)
 from libp2p.pubsub.pb import (
     rpc_pb2,
 )
@@ -354,6 +357,11 @@ async def test_continuously_read_stream(monkeypatch, nursery, security_protocol)
                 await wait_for_event_occurring(events.push_msg)
             with pytest.raises(trio.TooSlowError):
                 await wait_for_event_occurring(events.handle_subscription)
+        # After all messages, close the write end to signal EOF
+        await stream_pair[1].close()
+        # Now reading should raise StreamEOF
+        with pytest.raises(StreamEOF):
+            await stream_pair[0].read(1)
 
 
 # TODO: Add the following tests after they are aligned with Go.


### PR DESCRIPTION
@paschal533 @pacrob @seetadev

This PR integrates the muxer selection functionality with Noise transport support. Changes include:

- Added functionality to choose between Yamux and Mplex multiplexers
- Added tests for switching between Yamux and Mplex
- Integrated Noise transport as the primary security transport
- Moved host fixtures to interop tests for better organization
- Fixed timing issues in tests

The changes maintain backward compatibility while making Yamux the default multiplexer.